### PR TITLE
Add Clowder URL hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PYTHON_VERSION=${PYTHON_VERSION} \
     RABBITMQ_URI="amqp://guest:guest@rabbitmq:5672/%2F" \
     RABBITMQ_EXCHANGE="clowder" \
     RABBITMQ_QUEUE="" \
+    CLOWDER_URL="" \
     REGISTRATION_ENDPOINTS="" \
     EMAIL_SERVER="" \
     EMAIL_SENDER="extractor" \

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -762,7 +762,7 @@ class RabbitMQConnector(Connector):
                 json_body['routing_key'] = method.routing_key
 
             self.worker = RabbitMQHandler(self.extractor_name, self.extractor_info, self.check_message,
-                                          self.process_message, self.ssl_verify, self.mounted_paths,
+                                          self.process_message, self.ssl_verify, self.mounted_paths, self.clowder_url,
                                           method, header, body)
             self.worker.start_thread(json_body)
 
@@ -837,9 +837,9 @@ class RabbitMQHandler(Connector):
     """
 
     def __init__(self, extractor_name, extractor_info, check_message=None, process_message=None, ssl_verify=True,
-                 mounted_paths=None, method=None, header=None, body=None):
+                 mounted_paths=None, clowder_url=None, method=None, header=None, body=None):
         super(RabbitMQHandler, self).__init__(extractor_name, extractor_info, check_message, process_message,
-                                              ssl_verify, mounted_paths)
+                                              ssl_verify, mounted_paths, clowder_url)
         self.method = method
         self.header = header
         self.body = body

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -66,7 +66,7 @@ class Connector(object):
     registered_clowder = list()
 
     def __init__(self, extractor_name, extractor_info, check_message=None, process_message=None, ssl_verify=True,
-                 mounted_paths=None):
+                 mounted_paths=None, clowder_url=None):
         self.extractor_name = extractor_name
         self.extractor_info = extractor_info
         self.check_message = check_message
@@ -76,6 +76,7 @@ class Connector(object):
             self.mounted_paths = {}
         else:
             self.mounted_paths = mounted_paths
+        self.clowder_url = clowder_url
 
         filename = 'notifications.json'
         self.smtp_server = None
@@ -374,7 +375,7 @@ class Connector(object):
         if body.get('notifies'):
             emailaddrlist = body.get('notifies')
             logger.debug(emailaddrlist)
-        host = body.get('host', '')
+        host = self.clowder_url if self.clowder_url is not None else body.get('host', '')
         if host == '':
             return
         elif not host.endswith('/'):
@@ -623,9 +624,9 @@ class RabbitMQConnector(Connector):
     def __init__(self, extractor_name, extractor_info,
                  rabbitmq_uri, rabbitmq_exchange=None, rabbitmq_key=None, rabbitmq_queue=None,
                  check_message=None, process_message=None, ssl_verify=True, mounted_paths=None,
-                 heartbeat=5*60):
+                 heartbeat=5*60, clowder_url=None):
         super(RabbitMQConnector, self).__init__(extractor_name, extractor_info, check_message, process_message,
-                                                ssl_verify, mounted_paths)
+                                                ssl_verify, mounted_paths, clowder_url)
         self.rabbitmq_uri = rabbitmq_uri
         self.rabbitmq_exchange = rabbitmq_exchange
         self.rabbitmq_key = rabbitmq_key
@@ -638,7 +639,7 @@ class RabbitMQConnector(Connector):
         self.consumer_tag = None
         self.worker = None
         self.announcer = None
-        self.heartbeat = 5*60
+        self.heartbeat = heartbeat
 
     def connect(self):
         """connect to rabbitmq using URL parameters"""

--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -63,6 +63,7 @@ class Extractor(object):
             rabbitmq_queuename = self.extractor_info['name']
         rabbitmq_uri = os.getenv('RABBITMQ_URI', "amqp://guest:guest@127.0.0.1/%2f")
         rabbitmq_exchange = os.getenv('RABBITMQ_EXCHANGE', "clowder")
+        clowder_url = os.getenv("CLOWDER_URL", "")
         registration_endpoints = os.getenv('REGISTRATION_ENDPOINTS', "")
         logging_config = os.getenv("LOGGING")
         mounted_paths = os.getenv("MOUNTED_PATHS", "{}")
@@ -84,6 +85,8 @@ class Extractor(object):
         self.parser.add_argument('--pickle', nargs='*', dest="hpc_picklefile",
                                  default=None, action='append',
                                  help='pickle file that needs to be processed (only needed for HPC)')
+        self.parser.add_argument('--clowderURL', nargs='?', dest='clowder_url', default=clowder_url,
+                                 help='Clowder host URL')
         self.parser.add_argument('--register', '-r', nargs='?', dest="registration_endpoints",
                                  default=registration_endpoints,
                                  help='Clowder registration URL (default=%s)' % registration_endpoints)

--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -161,7 +161,8 @@ class Extractor(object):
                                               rabbitmq_exchange=self.args.rabbitmq_exchange,
                                               rabbitmq_key=rabbitmq_key,
                                               rabbitmq_queue=self.args.rabbitmq_queuename,
-                                              mounted_paths=json.loads(self.args.mounted_paths))
+                                              mounted_paths=json.loads(self.args.mounted_paths),
+                                              clowder_url=self.args.clowder_url)
                     rconn.connect()
                     rconn.register_extractor(self.args.registration_endpoints)
                     connectors.append(rconn)


### PR DESCRIPTION
Add an environment variable and other code to support overriding of Clowder URL used by extractors. This will allow an extractor to use an internal server IP if the server environment supports it, to minimize firewall traversals and similar reasons.