### PR TITLE
50 clowder20 submit file to extractor

### DIFF
--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -409,6 +409,8 @@ class Connector(object):
         if not source_host.endswith('/'): source_host += '/'
         if not host.endswith('/'): host += '/'
         secret_key = body.get('secretKey', '')
+        if clowder_version >= 2.0:
+            secret_key = body.get('token', '')
         token = body.get('token', ' ')
         retry_count = 0 if 'retry_count' not in body else body['retry_count']
         resource = self._build_resource(body, host, secret_key)

--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -55,6 +55,7 @@ class Extractor(object):
         try:
             with open(filename) as info_file:
                 self.extractor_info = json.load(info_file)
+                new_info = self._get_extractor_info_v2()
         except Exception:  # pylint: disable=broad-except
             print("Error loading extractor_info.json")
             traceback.print_exc()
@@ -225,6 +226,16 @@ class Extractor(object):
             logger.exception("Error while consuming messages.")
         connector.stop()
 
+    def _get_extractor_info_v2(self):
+        current_extractor_info = self.extractor_info.copy()
+        repository = self.extractor_info['repository'][0]
+        new_repository = dict()
+        new_repository['repository_url'] = repository['repUrl']
+        new_repository['repository_type'] = repository['repType']
+        current_extractor_info['repository'] = new_repository
+        return current_extractor_info
+
+
     def get_metadata(self, content, resource_type, resource_id, server=None):
         """Generate a metadata field.
 
@@ -251,11 +262,13 @@ class Extractor(object):
                     logger.debug("Simple check could not find %s in contexts" % k)
         # TODO generate clowder2.0 extractor info
         if clowder_version >= 2.0:
+            new_extractor_info = self._get_extractor_info_v2()
             md = dict()
             md["file_version"] = 1
             md["context"] = self.extractor_info["contexts"][0]
             md["context_url"] = context_url
             md["contents"] = content
+            md["extractor_info"] = new_extractor_info
             return md
         else:
             return {

--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -24,6 +24,10 @@ from pyclowder.utils import CheckMessage, setup_logging
 import pyclowder.files
 import pyclowder.datasets
 
+from dotenv import load_dotenv
+load_dotenv()
+clowder_version = float(os.getenv('clowder_version'))
+
 
 class Extractor(object):
     """Basic extractor.
@@ -245,22 +249,30 @@ class Extractor(object):
             for k in content:
                 if not self._check_key(k, self.extractor_info['contexts']):
                     logger.debug("Simple check could not find %s in contexts" % k)
-
-        return {
-            '@context': [context_url] + self.extractor_info['contexts'],
-            'attachedTo': {
-                'resourceType': resource_type,
-                'id': resource_id
-            },
-            'agent': {
-                '@type': 'cat:extractor',
-                'extractor_id': '%sextractors/%s/%s' %
-                                (server, self.extractor_info['name'], self.extractor_info['version']),
-                'version': self.extractor_info['version'],
-                'name': self.extractor_info['name']
-            },
-            'content': content
-        }
+        # TODO generate clowder2.0 extractor info
+        if clowder_version >= 2.0:
+            md = dict()
+            md["file_version"] = 1
+            md["context"] = self.extractor_info["contexts"][0]
+            md["context_url"] = context_url
+            md["contents"] = content
+            return md
+        else:
+            return {
+                '@context': [context_url] + self.extractor_info['contexts'],
+                'attachedTo': {
+                    'resourceType': resource_type,
+                    'id': resource_id
+                },
+                'agent': {
+                    '@type': 'cat:extractor',
+                    'extractor_id': '%sextractors/%s/%s' %
+                                    (server, self.extractor_info['name'], self.extractor_info['version']),
+                    'version': self.extractor_info['version'],
+                    'name': self.extractor_info['name']
+                },
+                'content': content
+            }
 
     def _check_key(self, key, obj):
         if key in obj:

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -211,14 +211,23 @@ def upload_metadata(connector, host, key, fileid, metadata):
     metadata -- the metadata to be uploaded
     """
 
-    connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
+    if clowder_version >= 2.0:
+        connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
 
-    headers = {'Content-Type': 'application/json'}
-    # TODO if version 2.0
+        headers = {'Content-Type': 'application/json',
+                   'Authorization':'Bearer ' + key}
+        print(metadata)
+        url = '%sapi/v2/files/%s/metadata' % (host, fileid)
+        result = connector.post(url, headers=headers, data=json.dumps(metadata),
+                                verify=connector.ssl_verify if connector else True)
+    else:
+        connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
 
-    url = '%sapi/files/%s/metadata.jsonld?key=%s' % (host, fileid, key)
-    result = connector.post(url, headers=headers, data=json.dumps(metadata),
-                            verify=connector.ssl_verify if connector else True)
+        headers = {'Content-Type': 'application/json'}
+
+        url = '%sapi/files/%s/metadata.jsonld?key=%s' % (host, fileid, key)
+        result = connector.post(url, headers=headers, data=json.dumps(metadata),
+                                verify=connector.ssl_verify if connector else True)
 
 
 # pylint: disable=too-many-arguments

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -213,7 +213,6 @@ def upload_metadata(connector, host, key, fileid, metadata):
 
     if clowder_version >= 2.0:
         connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
-        as_json = json.dumps(metadata)
 
         headers = {'Content-Type': 'application/json',
                    'Authorization':'Bearer ' + key}

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -213,6 +213,7 @@ def upload_metadata(connector, host, key, fileid, metadata):
 
     if clowder_version >= 2.0:
         connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
+        as_json = json.dumps(metadata)
 
         headers = {'Content-Type': 'application/json',
                    'Authorization':'Bearer ' + key}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ requests-toolbelt==0.9.1
     # via pyclowder (setup.py)
 urllib3==1.26.8
     # via requests
+dotenv

--- a/sample-extractors/csv-precipitation/Dockerfile
+++ b/sample-extractors/csv-precipitation/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYCLOWDER_PYTHON=""
+FROM clowder/pyclowder${PYCLOWDER_PYTHON}:onbuild
+
+ENV MAIN_SCRIPT="binary_extractor.py" \
+    RABBITMQ_QUEUE="" \
+    IMAGE_BINARY="" \
+    IMAGE_TYPE="" \
+    IMAGE_THUMBNAIL_COMMAND="" \
+    IMAGE_PREVIEW_COMMAND="" \
+    PREVIEW_BINARY="" \
+    PREVIEW_TYPE="" \
+    PREVIEW_COMMAND=""
+
+ONBUILD COPY packages.* Dockerfile /home/clowder/
+ONBUILD RUN if [ -e packages.apt ]; then \
+                apt-get -q -q update \
+                && xargs apt-get -y install --no-install-recommends < packages.apt \
+                && rm -rf /var/lib/apt/lists/*; \
+            fi
+
+ONBUILD COPY extractor_info.json /home/clowder/

--- a/sample-extractors/csv-precipitation/README.rst
+++ b/sample-extractors/csv-precipitation/README.rst
@@ -1,0 +1,66 @@
+A simple extractor that can execute binary programs to generate image previews, thumbnails, as well as previews. To
+use this extractor you will need to create a new Dockerfile that sets environment variables, a packages.apt file that
+lists all the packages that need to be installed, and an extractor_info.json that describes the extractor.
+
+For example the following files will create an extractor that can handle audio files. To build the extractor you can
+use `docker build -t clowder/extractor-audio`. You can now use the extractor in your clowder environment. For example
+if you used the docker-compose file to start clowder yo can add this extractor to the running stack using
+`docker run --rm --network clowder --link rabbitmq --link clowder clowder/extractor-audio` when you now upload an
+audio file it will automatically create a thumbnail, image preview and audio preview.
+
+Dockerfile
+
+.. code-block:: Dockerfile
+
+    FROM clowder/pyclowder:onbuild
+
+    ENV RABBITMQ_QUEUE="ncsa.audio.preview" \
+        IMAGE_BINARY="/usr/bin/sox" \
+        IMAGE_TYPE="png" \
+        IMAGE_THUMBNAIL_COMMAND="@BINARY@ --magic @INPUT@ -n spectrogram -r -x 225 -y 200 -o @OUTPUT@" \
+        IMAGE_PREVIEW_COMMAND="@BINARY@ --magic @INPUT@ -n spectrogram -x 800 -Y 600 -o @OUTPUT@" \
+        PREVIEW_BINARY="/usr/bin/sox" \
+        PREVIEW_TYPE="mp3" \
+        PREVIEW_COMMAND="@BINARY@ --magic @INPUT@ @OUTPUT@"
+
+
+packages.apt
+
+.. code-block::
+
+    libsox-fmt-mp3 sox
+
+extractor_info.json
+
+.. code-block:: json
+
+    {
+       "@context":"http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
+       "name":"ncsa.audio.preview",
+       "version":"1.0",
+       "description":"Creates thumbnail and image previews of Audio files.",
+       "author":"Rob Kooper <kooper@illinois.edu>",
+       "contributors":[],
+       "contexts":[],
+       "repository":[
+          {
+             "repType":"git",
+             "repUrl":"https://opensource.ncsa.illinois.edu/bitbucket/scm/cats/extractors-core.git"
+          },
+          {
+             "repType":"docker",
+             "repUrl":"clowder/extractors-audio-preview"
+          }
+       ],
+       "external_services":[],
+       "process":{
+          "file":[
+             "audio/*"
+          ]
+       },
+       "dependencies":[
+          "sox-fmt-mp3",
+          "sox"
+       ],
+       "bibtex":[]
+    }

--- a/sample-extractors/csv-precipitation/binary_extractor.py
+++ b/sample-extractors/csv-precipitation/binary_extractor.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+
+from pyclowder.extractors import Extractor
+import pyclowder.files
+import pyclowder.utils
+
+
+class BinaryPreviewExtractor(Extractor):
+    """Count the number of characters, words and lines in a text file."""
+    def __init__(self):
+        Extractor.__init__(self)
+
+        image_binary = os.getenv('IMAGE_BINARY', '')
+        image_type = os.getenv('IMAGE_TYPE', 'png')
+        image_thumbnail_command = os.getenv('IMAGE_THUMBNAIL_COMMAND', '@BINARY@ @INPUT@ @OUTPUT@')
+        image_preview_command = os.getenv('IMAGE_PREVIEW_COMMAND', '@BINARY@ @INPUT@ @OUTPUT@')
+        preview_binary = os.getenv('PREVIEW_BINARY', '')
+        preview_type = os.getenv('PREVIEW_TYPE', '')
+        preview_command = os.getenv('PREVIEW_COMMAND', '@BINARY@ @INPUT@ @OUTPUT@')
+
+        # add any additional arguments to parser
+        self.parser.add_argument('--image-binary', nargs='?', dest='image_binary', default=image_binary,
+                                 help='Image Binary used to for image thumbnail/preview (default=%s)' % image_binary)
+        self.parser.add_argument('--image-type', nargs='?', dest='image_type', default=image_type,
+                                 help='Image type of thumbnail/preview (default=%s)' % image_type)
+        self.parser.add_argument('--image-thumbnail-command', nargs='?', dest='image_thumbnail_command',
+                                 default=image_thumbnail_command,
+                                 help='Image command line for thumbnail (default=%s)' % image_thumbnail_command)
+        self.parser.add_argument('--image-preview-command', nargs='?', dest='image_preview_command',
+                                 default=image_preview_command,
+                                 help='Image command line for preview (default=%s)' % image_preview_command)
+        self.parser.add_argument('--preview-binary', nargs='?', dest='preview_binary', default=preview_binary,
+                                 help='Binary used to generate preview (default=%s)' % preview_binary)
+        self.parser.add_argument('--preview-type', nargs='?', dest='preview_type', default=preview_type,
+                                 help='Preview type (default=%s)' % preview_type)
+        self.parser.add_argument('--preview-command', nargs='?', dest='preview_command', default=preview_command,
+                                 help='Command line for preview (default=%s)' % preview_command)
+
+        # parse command line and load default logging configuration
+        self.setup()
+
+        # setup logging for the exctractor
+        logging.getLogger('pyclowder').setLevel(logging.DEBUG)
+        logging.getLogger('__main__').setLevel(logging.DEBUG)
+
+    def process_message(self, connector, host, secret_key, resource, parameters):
+        # Process the file and upload the results
+
+        inputfile = resource["local_paths"][0]
+        file_id = resource['id']
+
+        # create thumbnail image
+        if 'image_thumbnail' in parameters:
+            args = parameters['image_thumbnail']
+        else:
+            args = self.args.image_thumbnail_command
+        self.execute_command(connector, host, secret_key, inputfile, file_id, resource, False,
+                             self.args.image_binary, args, self.args.image_type)
+
+        # create preview image
+        if 'image_preview' in parameters:
+            args = parameters['image_preview']
+        else:
+            args = self.args.image_preview_command
+        self.execute_command(connector, host, secret_key, inputfile, file_id, resource, True,
+                             self.args.image_binary, args, self.args.image_type)
+
+        # create extractor specifc preview
+        if 'preview' in parameters:
+            args = parameters['preview']
+        else:
+            args = self.args.preview_command
+        self.execute_command(connector, host, secret_key, inputfile, file_id, resource, True,
+                             self.args.preview_binary, args, self.args.preview_type)
+
+    @staticmethod
+    def execute_command(connector, host, key, inputfile, fileid, resource, preview, binary, commandline, ext):
+        logger = logging.getLogger(__name__)
+
+        if binary is None or binary == '' or commandline is None or commandline == '' or ext is None or ext == '':
+            return
+
+        (fd, tmpfile) = tempfile.mkstemp(suffix='.' + ext)
+        try:
+            # close tempfile
+            os.close(fd)
+
+            # replace some special tokens
+            commandline = commandline.replace('@BINARY@', binary)
+            commandline = commandline.replace('@INPUT@', inputfile)
+            commandline = commandline.replace('@OUTPUT@', tmpfile)
+
+            # split command line
+            p = re.compile(r'''((?:[^ "']|"[^"]*"|'[^']*')+)''')
+            commandline = p.split(commandline)[1::2]
+
+            # execute command
+            x = subprocess.check_output(commandline, stderr=subprocess.STDOUT)
+            x = x.decode('utf-8')
+            if x:
+                logger.debug(binary + " : " + x)
+
+            if os.path.getsize(tmpfile) != 0:
+                # upload result
+                if preview:
+                    pyclowder.files.upload_preview(connector, host, key, fileid, tmpfile, None)
+                    connector.status_update(pyclowder.utils.StatusMessage.processing, resource,
+                                            "Uploaded preview of type %s" % ext)
+                else:
+                    pyclowder.files.upload_thumbnail(connector, host, key, fileid, tmpfile)
+                    connector.status_update(pyclowder.utils.StatusMessage.processing, resource,
+                                            "Uploaded thumbnail of type %s" % ext)
+            else:
+                logger.warning("Extraction resulted in 0 byte file, nothing uploaded.")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(binary + " : " + str(e.output))
+            raise
+        finally:
+            try:
+                os.remove(tmpfile)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    extractor = BinaryPreviewExtractor()
+    extractor.start()


### PR DESCRIPTION
These changes will allow a file to be submitted to an extractor and the metadata will post. I have not yet handled cases where new files are uploaded or tags. Easiest way to test is to use the wordcount extractor. 

With this branch, add .env file to the pyclowder directory and put in

``
clowder_version=2.0

``

Right now I am sending in the Bearer Token from clowder2.0, and then using the Bearer Token in place of the extractor-key or secretKey. I am not sure that this will be a good strategy long term. If an extractor takes a long time to complete, the token may expire, but this seemed like a good enough approach for now. 

The branch this works with for clowder2.0 is 

https://github.com/clowder-framework/clowder2/tree/register-extractor-submit-file
