### PR TITLE
changing python versions to fix errors in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Changing the python versions to fix errors in the tests. New versions are 3.7, 3.9 and 3.11