### PR TITLE
Change v2 endpoints to API Keys instead of Bearer tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.1 - 2023-05-25
+
+### Changed
+This version updates Clowder 2 functionality to use API Key headers instead of Bearer tokens.
+
 ## 3.0.0 - 2022-12-16
 This version adds Clowder 2 support and removes the old method of extractor registration in favor of reliance on heartbeats.
 

--- a/pyclowder/api/v1/datasets.py
+++ b/pyclowder/api/v1/datasets.py
@@ -123,13 +123,11 @@ def download_metadata(connector, client, datasetid, extractor=None):
     datasetid -- the dataset to fetch metadata of
     extractor -- extractor name to filter results (if only one extractor's metadata is desired)
     """
-    headers = {"Authorization": "Bearer " + client.key}
-
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
-    url = '%s/api/datasets/%s/metadata?key=%s' % (client.host, datasetid, client.key)
+    url = '%s/api/datasets/%s/metadata?key=%s' % (client.host, datasetid, client.key + filterstring)
 
     # fetch data
-    result = requests.get(url, stream=True, headers=headers,
+    result = requests.get(url, stream=True,
                           verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
 

--- a/pyclowder/api/v2/datasets.py
+++ b/pyclowder/api/v2/datasets.py
@@ -31,7 +31,7 @@ def create_empty(connector, client, datasetname, description, parentid=None, spa
 
     url = '%s/api/v2/datasets' % client.host
     headers = {"Content-Type": "application/json",
-               "x-api-key": client.key}
+               "X-API-KEY": client.key}
     result = requests.post(url, headers=headers,
                            data=json.dumps({"name": datasetname, "description": description}),
                            verify=connector.ssl_verify if connector else True)
@@ -52,7 +52,7 @@ def delete(connector, client , datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to delete
     """
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
     url = "%s/api/v2/datasets/%s" % (client.host, datasetid)
 
     result = requests.delete(url, headers=headers, verify=connector.ssl_verify if connector else True)
@@ -96,7 +96,7 @@ def download(connector, client, datasetid):
 
     connector.message_process({"type": "dataset", "id": datasetid}, "Downloading dataset.")
 
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
     # fetch dataset zipfile
     url = '%s/api/v2/datasets/%s/download' % (client.host, datasetid)
     result = requests.get(url, stream=True, headers=headers,
@@ -120,7 +120,7 @@ def download_metadata(connector, client, datasetid, extractor=None):
     datasetid -- the dataset to fetch metadata of
     extractor -- extractor name to filter results (if only one extractor's metadata is desired)
     """
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
 
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
     url = '%s/api/v2/datasets/%s/metadata' % (client.host, datasetid)
@@ -141,7 +141,7 @@ def get_info(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to get info of
     """
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
 
     url = "%s/api/v2/datasets/%s" % (client.host, datasetid)
 
@@ -160,7 +160,7 @@ def get_file_list(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to get filelist of
     """
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
 
     url = "%s/api/v2/datasets/%s/files" % (client.host, datasetid)
 
@@ -180,7 +180,7 @@ def remove_metadata(connector, client, datasetid, extractor=None):
     extractor -- extractor name to filter deletion
                     !!! ALL JSON-LD METADATA WILL BE REMOVED IF NO extractor PROVIDED !!!
     """
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
 
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
     url = '%s/api/v2/datasets/%s/metadata' % (client.host, datasetid)
@@ -201,7 +201,7 @@ def submit_extraction(connector, client, datasetid, extractorname):
     extractorname -- registered name of extractor to trigger
     """
     headers = {'Content-Type': 'application/json',
-                "x-api-key": client.key}
+                "X-API-KEY": client.key}
 
     url = "%s/api/v2/datasets/%s/extractions?key=%s" % (client.host, datasetid)
 
@@ -224,7 +224,7 @@ def upload_metadata(connector, client, datasetid, metadata):
     metadata -- the metadata to be uploaded
     """
     headers = {'Content-Type': 'application/json',
-               "x-api-key": client.key}
+               "X-API-KEY": client.key}
     connector.message_process({"type": "dataset", "id": datasetid}, "Uploading dataset metadata.")
 
 

--- a/pyclowder/api/v2/datasets.py
+++ b/pyclowder/api/v2/datasets.py
@@ -31,7 +31,7 @@ def create_empty(connector, client, datasetname, description, parentid=None, spa
 
     url = '%s/api/v2/datasets' % client.host
     headers = {"Content-Type": "application/json",
-               "Authorization": "Bearer " + client.key}
+               "x-api-key": client.key}
     result = requests.post(url, headers=headers,
                            data=json.dumps({"name": datasetname, "description": description}),
                            verify=connector.ssl_verify if connector else True)
@@ -52,8 +52,7 @@ def delete(connector, client , datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to delete
     """
-    headers = {"Authorization": "Bearer " + client.key}
-
+    headers = {"x-api-key": client.key}
     url = "%s/api/v2/datasets/%s" % (client.host, datasetid)
 
     result = requests.delete(url, headers=headers, verify=connector.ssl_verify if connector else True)
@@ -97,7 +96,7 @@ def download(connector, client, datasetid):
 
     connector.message_process({"type": "dataset", "id": datasetid}, "Downloading dataset.")
 
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
     # fetch dataset zipfile
     url = '%s/api/v2/datasets/%s/download' % (client.host, datasetid)
     result = requests.get(url, stream=True, headers=headers,
@@ -121,7 +120,7 @@ def download_metadata(connector, client, datasetid, extractor=None):
     datasetid -- the dataset to fetch metadata of
     extractor -- extractor name to filter results (if only one extractor's metadata is desired)
     """
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
 
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
     url = '%s/api/v2/datasets/%s/metadata' % (client.host, datasetid)
@@ -142,7 +141,7 @@ def get_info(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to get info of
     """
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
 
     url = "%s/api/v2/datasets/%s" % (client.host, datasetid)
 
@@ -161,7 +160,7 @@ def get_file_list(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to get filelist of
     """
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
 
     url = "%s/api/v2/datasets/%s/files" % (client.host, datasetid)
 
@@ -181,7 +180,7 @@ def remove_metadata(connector, client, datasetid, extractor=None):
     extractor -- extractor name to filter deletion
                     !!! ALL JSON-LD METADATA WILL BE REMOVED IF NO extractor PROVIDED !!!
     """
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
 
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
     url = '%s/api/v2/datasets/%s/metadata' % (client.host, datasetid)
@@ -202,7 +201,7 @@ def submit_extraction(connector, client, datasetid, extractorname):
     extractorname -- registered name of extractor to trigger
     """
     headers = {'Content-Type': 'application/json',
-                "Authorization": "Bearer " + client.key}
+                "x-api-key": client.key}
 
     url = "%s/api/v2/datasets/%s/extractions?key=%s" % (client.host, datasetid)
 
@@ -225,7 +224,7 @@ def upload_metadata(connector, client, datasetid, metadata):
     metadata -- the metadata to be uploaded
     """
     headers = {'Content-Type': 'application/json',
-               "Authorization": "Bearer " + client.key}
+               "x-api-key": client.key}
     connector.message_process({"type": "dataset", "id": datasetid}, "Uploading dataset metadata.")
 
 

--- a/pyclowder/api/v2/files.py
+++ b/pyclowder/api/v2/files.py
@@ -65,7 +65,7 @@ def download(connector, client, fileid, intermediatefileid=None, ext=""):
         intermediatefileid = fileid
 
     url = '%s/api/v2/files/%s' % (client.host, intermediatefileid)
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
 
     (inputfile, inputfilename) = tempfile.mkstemp(suffix=ext)
@@ -90,7 +90,7 @@ def download_info(connector, client, fileid):
     """
 
     url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
 
@@ -109,7 +109,7 @@ def download_metadata(connector,client, fileid, extractor=None):
 
     filterstring = "" if extractor is None else "?extractor=%s" % extractor
     url = '%s/api/v2/files/%s/metadata?%s' % (client.host, fileid, filterstring)
-    headers = {"x-api-key": client.key}
+    headers = {"X-API-KEY": client.key}
 
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
@@ -130,7 +130,7 @@ def submit_extraction(connector, client, fileid, extractorname):
     url = "%s/api/v2/files/%s/extractions?key=%s" % (client.host, fileid, client.key)
     result = connector.post(url,
                             headers={'Content-Type': 'application/json',
-                                     "x-api-key": client.key},
+                                     "X-API-KEY": client.key},
                             data=json.dumps({"extractor": extractorname}),
                             verify=connector.ssl_verify if connector else True)
 
@@ -149,7 +149,7 @@ def upload_metadata(connector, client, fileid, metadata):
 
     connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
     headers = {'Content-Type': 'application/json',
-               'x-api-key': client.key}
+               'X-API-KEY': client.key}
     url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
     result = connector.post(url, headers=headers, data=json.dumps(metadata),
                             verify=connector.ssl_verify if connector else True)
@@ -283,7 +283,7 @@ def upload_to_dataset(connector, client, datasetid, filepath, check_duplicate=Fa
         m = MultipartEncoder(
             fields={'file': (filename, open(filepath, 'rb'))}
         )
-        headers = {"x-api-key": client.key,
+        headers = {"X-API-KEY": client.key,
                     'Content-Type': m.content_type}
         result = connector.post(url, data=m, headers=headers,
                                 verify=connector.ssl_verify if connector else True)
@@ -320,7 +320,7 @@ def _upload_to_dataset_local(connector, client, datasetid, filepath):
         m = MultipartEncoder(
             fields={'file': (filename, open(filepath, 'rb'))}
         )
-        headers = {"x-api-key": client.key,
+        headers = {"X-API-KEY": client.key,
                     'Content-Type': m.content_type}
         result = connector.post(url, data=m, headers=headers,
                                 verify=connector.ssl_verify if connector else True)

--- a/pyclowder/api/v2/files.py
+++ b/pyclowder/api/v2/files.py
@@ -65,7 +65,7 @@ def download(connector, client, fileid, intermediatefileid=None, ext=""):
         intermediatefileid = fileid
 
     url = '%s/api/v2/files/%s' % (client.host, intermediatefileid)
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
 
     (inputfile, inputfilename) = tempfile.mkstemp(suffix=ext)
@@ -90,7 +90,7 @@ def download_info(connector, client, fileid):
     """
 
     url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
 
@@ -109,7 +109,7 @@ def download_metadata(connector,client, fileid, extractor=None):
 
     filterstring = "" if extractor is None else "?extractor=%s" % extractor
     url = '%s/api/v2/files/%s/metadata?%s' % (client.host, fileid, filterstring)
-    headers = {"Authorization": "Bearer " + client.key}
+    headers = {"x-api-key": client.key}
 
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
@@ -130,7 +130,7 @@ def submit_extraction(connector, client, fileid, extractorname):
     url = "%s/api/v2/files/%s/extractions?key=%s" % (client.host, fileid, client.key)
     result = connector.post(url,
                             headers={'Content-Type': 'application/json',
-                                     "Authorization": "Bearer " + client.key},
+                                     "x-api-key": client.key},
                             data=json.dumps({"extractor": extractorname}),
                             verify=connector.ssl_verify if connector else True)
 
@@ -149,9 +149,7 @@ def upload_metadata(connector, client, fileid, metadata):
 
     connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
     headers = {'Content-Type': 'application/json',
-               'Authorization':'Bearer ' + client.key}
-    print(metadata)
-    as_json = json.dumps(metadata)
+               'x-api-key': client.key}
     url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
     result = connector.post(url, headers=headers, data=json.dumps(metadata),
                             verify=connector.ssl_verify if connector else True)
@@ -285,7 +283,7 @@ def upload_to_dataset(connector, client, datasetid, filepath, check_duplicate=Fa
         m = MultipartEncoder(
             fields={'file': (filename, open(filepath, 'rb'))}
         )
-        headers = {"Authorization": "Bearer " + client.key,
+        headers = {"x-api-key": client.key,
                     'Content-Type': m.content_type}
         result = connector.post(url, data=m, headers=headers,
                                 verify=connector.ssl_verify if connector else True)
@@ -322,7 +320,7 @@ def _upload_to_dataset_local(connector, client, datasetid, filepath):
         m = MultipartEncoder(
             fields={'file': (filename, open(filepath, 'rb'))}
         )
-        headers = {"Authorization": "Bearer " + client.key,
+        headers = {"x-api-key": client.key,
                     'Content-Type': m.content_type}
         result = connector.post(url, data=m, headers=headers,
                                 verify=connector.ssl_verify if connector else True)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'description.rst').read_text(encoding='utf-8')
 
 setup(
     name='pyclowder',
-    version='3.0.0',
+    version='3.0.1',
     description='Python SDK for the Clowder Data Management System',
     long_description=long_description,
 


### PR DESCRIPTION
Bumps version to 3.0.1. no more support for Bearer tokens from v2, only X-API-KEY.

Depends on this Clowder2 PR: https://github.com/clowder-framework/clowder2/pull/473