### PR TITLE
wrong file version for v2 metadata

### DIFF
--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -258,7 +258,6 @@ class Extractor(object):
         if clowder_version == 2.0:
             new_extractor_info = self._get_extractor_info_v2()
             md = dict()
-            md["file_version"] = 1
             if contexts is not None:
                 md["context"] = [context_url] + contexts
             md["context_url"] = context_url


### PR DESCRIPTION
Looks like for v2 the extractor was always putting the file version as 1, so extracted metadata always ended up on the wrong file version after it was updated. 

This is a small fix, should have impact v1 but did not test. 