### PR TITLE
3.0.6 Use posixpath.join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## 3.0.6 - 2023-10-10
+## 3.0.7 - 2023-10-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.0.6 - 2023-10-10
+
+### Added
+
+- Modified v1 and v2 endpoints to ignore trailing slashes on Clowder host URLs.
+
 - ## 3.0.5 - 2023-10-09
 
 ### Added

--- a/pyclowder/api/v1/datasets.py
+++ b/pyclowder/api/v1/datasets.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import tempfile
-
+import posixpath
 import requests
 from pyclowder.client import ClowderClient
 from pyclowder.collections import get_datasets, get_child_collections, delete as delete_collection
@@ -22,7 +22,7 @@ def create_empty(connector, client, datasetname, description, parentid=None, spa
     """
     logger = logging.getLogger(__name__)
 
-    url = '%s/api/datasets/createempty?key=%s' % (client.host, client.key)
+    url = posixpath.join(client.host, 'api/datasets/createempty?key=%s' % client.key)
 
     if parentid:
         if spaceid:
@@ -61,7 +61,7 @@ def delete(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to delete
     """
-    url = "%s/api/datasets/%s?key=%s" % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, "api/datasets/%s?key=%s" % (datasetid, client.key))
 
     result = requests.delete(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -102,7 +102,7 @@ def download(connector, client, datasetid):
     connector.message_process({"type": "dataset", "id": datasetid}, "Downloading dataset.")
 
     # fetch dataset zipfile
-    url = '%s/api/datasets/%s/download?key=%s' % (client.host, datasetid,client.key)
+    url = posixpath.join(client.host, 'api/datasets/%s/download?key=%s' % datasetid,client.key)
     result = requests.get(url, stream=True,
                           verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -124,7 +124,7 @@ def download_metadata(connector, client, datasetid, extractor=None):
     extractor -- extractor name to filter results (if only one extractor's metadata is desired)
     """
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
-    url = '%s/api/datasets/%s/metadata?key=%s' % (client.host, datasetid, client.key + filterstring)
+    url = posixpath.join(client.host, 'api/datasets/%s/metadata?key=%s' % (datasetid, client.key + filterstring))
 
     # fetch data
     result = requests.get(url, stream=True,
@@ -142,7 +142,7 @@ def get_info(connector, client, datasetid):
     datasetid -- the dataset to get info of
     """
 
-    url = "%s/api/datasets/%s?key=%s" % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, "api/datasets/%s?key=%s" % (datasetid, client.key))
 
     result = requests.get(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -157,7 +157,7 @@ def get_file_list(connector, client, datasetid):
     client -- ClowderClient containing authentication credentials
     datasetid -- the dataset to get filelist of
     """
-    url = "%s/api/datasets/%s/files?key=%s" % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, "api/datasets/%s/files?key=%s" % (datasetid, client.key))
 
     result = requests.get(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -175,7 +175,7 @@ def remove_metadata(connector, client, datasetid, extractor=None):
                     !!! ALL JSON-LD METADATA WILL BE REMOVED IF NO extractor PROVIDED !!!
     """
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
-    url = '%s/api/datasets/%s/metadata?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/datasets/%s/metadata?key=%s' % (datasetid, client.key))
 
     # fetch data
     result = requests.delete(url, stream=True, verify=connector.ssl_verify if connector else True)
@@ -192,7 +192,7 @@ def submit_extraction(connector, client, datasetid, extractorname):
     """
     headers = {'Content-Type': 'application/json'}
 
-    url = "%s/api/datasets/%s/extractions?key=%s" % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, "api/datasets/%s/extractions?key=%s" % (datasetid, client.key))
 
     result = requests.post(url,
                            headers=headers,
@@ -238,7 +238,7 @@ def upload_tags(connector, client, datasetid, tags):
     connector.status_update(StatusMessage.processing, {"type": "dataset", "id": datasetid}, "Uploading dataset tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%s/api/datasets/%s/tags?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/datasets/%s/tags?key=%s' % (client.host, datasetid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 
@@ -255,7 +255,7 @@ def upload_metadata(connector, client, datasetid, metadata):
     headers = {'Content-Type': 'application/json'}
     connector.message_process({"type": "dataset", "id": datasetid}, "Uploading dataset metadata.")
 
-    url = '%s/api/datasets/%s/metadata?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/datasets/%s/metadata?key=%s' % (datasetid, client.key))
     result = requests.post(url, headers=headers, data=json.dumps(metadata),
                            verify=connector.ssl_verify if connector else True)
     result.raise_for_status()

--- a/pyclowder/api/v1/datasets.py
+++ b/pyclowder/api/v1/datasets.py
@@ -238,7 +238,7 @@ def upload_tags(connector, client, datasetid, tags):
     connector.status_update(StatusMessage.processing, {"type": "dataset", "id": datasetid}, "Uploading dataset tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = posixpath.join(client.host, 'api/datasets/%s/tags?key=%s' % (client.host, datasetid, client.key))
+    url = posixpath.join(client.host, 'api/datasets/%s/tags?key=%s' % (datasetid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 

--- a/pyclowder/api/v1/files.py
+++ b/pyclowder/api/v1/files.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import tempfile
-
+import posixpath
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
@@ -43,7 +43,7 @@ def get_download_url(connector, client, fileid, intermediatefileid=None, ext="")
     if not intermediatefileid:
         intermediatefileid = fileid
 
-    url = '%s/api/files/%s?key=%s' % (client.host, intermediatefileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s?key=%s' % (intermediatefileid, client.key))
     return url
 
 
@@ -65,7 +65,7 @@ def download(connector, client, fileid, intermediatefileid=None, ext=""):
     if not intermediatefileid:
         intermediatefileid = fileid
 
-    url = '%s/api/files/%s?key=%s' % (client.host, intermediatefileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s?key=%s' % (intermediatefileid, client.key))
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True)
 
     (inputfile, inputfilename) = tempfile.mkstemp(suffix=ext)
@@ -89,7 +89,7 @@ def download_info(connector, client, fileid):
     fileid -- the file to fetch metadata of
     """
 
-    url = '%s/api/files/%s/metadata?key=%s' % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s/metadata?key=%s' % (fileid, client.key))
 
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True)
@@ -121,7 +121,7 @@ def download_metadata(connector, client, fileid, extractor=None):
     """
 
     filterstring = "" if extractor is None else "&extractor=%s" % extractor
-    url = '%s/api/files/%s/metadata.jsonld?key=%s%s' % (client.host, fileid, client.key, filterstring)
+    url = posixpath.join(client.host, 'api/files/%s/metadata.jsonld?key=%s%s' % (fileid, client.key, filterstring))
 
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True)
@@ -137,7 +137,7 @@ def delete(connector, client, fileid):
     client -- ClowderClient containing authentication credentials
     fileid -- the dataset to delete
     """
-    url = "%s/api/files/%s?key=%s" % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, "api/files/%s?key=%s" % (fileid, client.key))
 
     result = requests.delete(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -155,7 +155,7 @@ def submit_extraction(connector, client, fileid, extractorname):
     extractorname -- registered name of extractor to trigger
     """
 
-    url = "%s/api/files/%s/extractions?key=%s" % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, "api/files/%s/extractions?key=%s" % (fileid, client.key))
 
     result = connector.post(url,
                             headers={'Content-Type': 'application/json'},
@@ -229,7 +229,7 @@ def upload_metadata(connector, client, fileid, metadata):
     connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%s/api/files/%s/metadata.jsonld?key=%s' % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s/metadata.jsonld?key=%s' % (fileid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(metadata),
                             verify=connector.ssl_verify if connector else True)
 
@@ -255,7 +255,7 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
     headers = {'Content-Type': 'application/json'}
 
     # upload preview
-    url = '%s/api/previews?key=%s' % (client.host, client.key)
+    url = posixpath.join(client.host, 'api/previews?key=%s' % client.key)
     with open(previewfile, 'rb') as filebytes:
         # If a custom preview file MIME type is provided, use it to generate the preview file object.
         if preview_mimetype is not None:
@@ -269,13 +269,13 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
 
     # associate uploaded preview with orginal file
     if fileid and not (previewmetadata and 'section_id' in previewmetadata and previewmetadata['section_id']):
-        url = '%s/api/files/%s/previews/%s?key=%s' % (client.host, fileid, previewid, client.key)
+        url = posixpath.join(client.host, 'api/files/%s/previews/%s?key=%s' % (fileid, previewid, client.key))
         result = connector.post(url, headers=headers, data=json.dumps({}),
                                 verify=connector.ssl_verify if connector else True)
 
     # associate metadata with preview
     if previewmetadata is not None:
-        url = '%s/api/previews/%s/metadata?key=%s' % (client.host, previewid, client.key)
+        url = posixpath.join(client.host, 'api/previews/%s/metadata?key=%s' % (previewid, client.key))
         result = connector.post(url, headers=headers, data=json.dumps(previewmetadata),
                                 verify=connector.ssl_verify if connector else True)
 
@@ -295,7 +295,7 @@ def upload_tags(connector, client, fileid, tags):
     connector.message_process({"type": "file", "id": fileid}, "Uploading file tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%s/api/files/%s/tags?key=%s' % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s/tags?key=%s' % (fileid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 
@@ -311,7 +311,7 @@ def upload_thumbnail(connector, client, fileid, thumbnail):
     """
 
     logger = logging.getLogger(__name__)
-    url = '%s/api/fileThumbnail?key=%s' % (client.host, client.key)
+    url = posixpath.join(client.host, 'api/fileThumbnail?key=%s' % client.key)
 
     # upload preview
     with open(thumbnail, 'rb') as inputfile:
@@ -322,7 +322,7 @@ def upload_thumbnail(connector, client, fileid, thumbnail):
     # associate uploaded preview with original file/dataset
     if fileid:
         headers = {'Content-Type': 'application/json'}
-        url = '%s/api/files/%s/thumbnails/%s?key=%s' % (client.host, fileid, thumbnailid, client.key)
+        url = posixpath.join(client.host, 'api/files/%s/thumbnails/%s?key=%s' % (fileid, thumbnailid, client.key))
         connector.post(url, headers=headers, data=json.dumps({}), verify=connector.ssl_verify if connector else True)
 
     return thumbnailid
@@ -352,7 +352,7 @@ def upload_to_dataset(connector, client, datasetid, filepath, check_duplicate=Fa
         if filepath.startswith(connector.mounted_paths[source_path]):
             return _upload_to_dataset_local(connector, client, datasetid, filepath)
 
-    url = '%s/api/uploadToDataset/%s?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/uploadToDataset/%s?key=%s' % (datasetid, client.key))
 
     if os.path.exists(filepath):
         filename = os.path.basename(filepath)
@@ -381,7 +381,7 @@ def _upload_to_dataset_local(connector, client, datasetid, filepath):
     """
 
     logger = logging.getLogger(__name__)
-    url = '%s/api/uploadToDataset/%s?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/uploadToDataset/%s?key=%s' % (datasetid, client.key))
 
     if os.path.exists(filepath):
         # Replace local path with remote path before uploading

--- a/pyclowder/api/v2/files.py
+++ b/pyclowder/api/v2/files.py
@@ -211,7 +211,7 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
     if os.path.exists(previewfile):
 
         # upload visualization URL
-        visualization_config_url = posixpath.join(client.host, 'api/v2/visualizations/config' % client.host)
+        visualization_config_url = posixpath.join(client.host, 'api/v2/visualizations/config')
 
         if visualization_config_data is None:
             visualization_config_data = dict()
@@ -244,10 +244,9 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
         if visualization_config_id is not None:
 
             # upload visualization URL
-            visualization_url = url = posixpath.join(client.host,
-                                                     'api/v2/visualizations?name=%s&description=%s&config=%s' % (
-                                                         client.host, visualization_name,
-                                                         visualization_description, visualization_config_id))
+            visualization_url = posixpath.join(client.host,
+                                               'api/v2/visualizations?name=%s&description=%s&config=%s' % (
+                                                   visualization_name, visualization_description, visualization_config_id))
 
             filename = os.path.basename(previewfile)
             if preview_mimetype is not None:

--- a/pyclowder/api/v2/files.py
+++ b/pyclowder/api/v2/files.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import tempfile
-
+import posixpath
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
@@ -40,7 +40,7 @@ def get_download_url(connector, client, fileid, intermediatefileid=None, ext="")
     if not intermediatefileid:
         intermediatefileid = fileid
 
-    url = '%s/api/v2/files/%s' % (client.host, intermediatefileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s' % intermediatefileid)
     return url
 
 
@@ -62,7 +62,7 @@ def download(connector, client, fileid, intermediatefileid=None, ext=""):
     if not intermediatefileid:
         intermediatefileid = fileid
 
-    url = '%s/api/v2/files/%s' % (client.host, intermediatefileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s' % intermediatefileid)
     headers = {"X-API-KEY": client.key}
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
 
@@ -87,7 +87,7 @@ def download_info(connector, client, fileid):
     fileid -- the file to fetch metadata of
     """
 
-    url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s/metadata' % fileid)
     headers = {"X-API-KEY": client.key}
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
@@ -104,7 +104,7 @@ def download_summary(connector, client, fileid):
     fileid -- the file to fetch metadata of
     """
 
-    url = '%s/api/v2/files/%s/summary' % (client.host, fileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s/summary' % fileid)
     headers = {"X-API-KEY": client.key}
     # fetch data
     result = connector.get(url, stream=True, verify=connector.ssl_verify if connector else True, headers=headers)
@@ -123,7 +123,7 @@ def download_metadata(connector, client, fileid, extractor=None):
     """
 
     filterstring = "" if extractor is None else "?extractor=%s" % extractor
-    url = '%s/api/v2/files/%s/metadata%s' % (client.host, fileid, filterstring)
+    url = posixpath.join(client.host, 'api/v2/files/%s/metadata%s' % (fileid, filterstring))
     headers = {"X-API-KEY": client.key}
 
     # fetch data
@@ -141,7 +141,7 @@ def delete(connector, client , fileid):
     fileid -- the dataset to delete
     """
     headers = {"X-API-KEY": client.key}
-    url = "%s/api/v2/files/%s" % (client.host, fileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s' % fileid)
 
     result = requests.delete(url, headers=headers, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -158,10 +158,9 @@ def submit_extraction(connector, client, fileid, extractorname):
     extractorname -- registered name of extractor to trigger
     """
 
-    url = "%s/api/v2/files/%s/extractions?key=%s" % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, "api/v2/files/%s/extractions" % fileid)
     result = connector.post(url,
-                            headers={'Content-Type': 'application/json',
-                                     "X-API-KEY": client.key},
+                            headers={'Content-Type': 'application/json', "X-API-KEY": client.key},
                             data=json.dumps({"extractor": extractorname}),
                             verify=connector.ssl_verify if connector else True)
 
@@ -181,7 +180,7 @@ def upload_metadata(connector, client, fileid, metadata):
     connector.message_process({"type": "file", "id": fileid}, "Uploading file metadata.")
     headers = {'Content-Type': 'application/json',
                'X-API-KEY': client.key}
-    url = '%s/api/v2/files/%s/metadata' % (client.host, fileid)
+    url = posixpath.join(client.host, 'api/v2/files/%s/metadata' % fileid)
     result = connector.post(url, headers=headers, data=json.dumps(metadata),
                             verify=connector.ssl_verify if connector else True)
 
@@ -212,7 +211,7 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
     if os.path.exists(previewfile):
 
         # upload visualization URL
-        visualization_config_url = '%s/api/v2/visualizations/config' % client.host
+        visualization_config_url = posixpath.join(client.host, 'api/v2/visualizations/config' % client.host)
 
         if visualization_config_data is None:
             visualization_config_data = dict()
@@ -245,8 +244,10 @@ def upload_preview(connector, client, fileid, previewfile, previewmetadata=None,
         if visualization_config_id is not None:
 
             # upload visualization URL
-            visualization_url = '%s/api/v2/visualizations?name=%s&description=%s&config=%s' % (
-                client.host, visualization_name, visualization_description, visualization_config_id)
+            visualization_url = url = posixpath.join(client.host,
+                                                     'api/v2/visualizations?name=%s&description=%s&config=%s' % (
+                                                         client.host, visualization_name,
+                                                         visualization_description, visualization_config_id))
 
             filename = os.path.basename(previewfile)
             if preview_mimetype is not None:
@@ -284,7 +285,7 @@ def upload_tags(connector, client, fileid, tags):
     connector.message_process({"type": "file", "id": fileid}, "Uploading file tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%s/api/files/%s/tags?key=%s' % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s/tags?key=%s' % (fileid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 
@@ -304,7 +305,7 @@ def upload_thumbnail(connector, client, fileid, thumbnail):
 
     connector.message_process({"type": "file", "id": fileid}, "Uploading thumbnail to file.")
 
-    url = '%s/api/v2/thumbnails' % (client.host)
+    url = posixpath.join(client.host, 'api/v2/thumbnails')
 
     if os.path.exists(thumbnail):
         file_data = {"file": open(thumbnail, 'rb')}
@@ -316,7 +317,7 @@ def upload_thumbnail(connector, client, fileid, thumbnail):
         logger.debug("uploaded thumbnail id = [%s]", thumbnailid)
         headers = {'Content-Type': 'application/json',
                    'X-API-KEY': client.key}
-        url = '%s/api/v2/files/%s/thumbnail/%s' % (client.host, fileid, thumbnailid)
+        url = posixpath.join(client.host, 'api/v2/files/%s/thumbnail/%s' % (fileid, thumbnailid))
         result = connector.patch(url, headers=headers,
                                  verify=connector.ssl_verify if connector else True)
         return result.json()["thumbnail_id"]
@@ -348,7 +349,7 @@ def upload_to_dataset(connector, client, datasetid, filepath, check_duplicate=Fa
         if filepath.startswith(connector.mounted_paths[source_path]):
             return _upload_to_dataset_local(connector, client, datasetid, filepath)
 
-    url = '%s/api/v2/datasets/%s/files' % (client.host, datasetid)
+    url = posixpath.join(client.host, 'api/v2/datasets/%s/files' % datasetid)
 
     if os.path.exists(filepath):
         filename = os.path.basename(filepath)
@@ -378,7 +379,7 @@ def _upload_to_dataset_local(connector, client, datasetid, filepath):
     filepath -- path to file
     """
     logger = logging.getLogger(__name__)
-    url = '%s/api/v2/datatsets/%s/files' % (client.host, datasetid)
+    url = posixpath.join(client.host, 'api/v2/datatsets/%s/files' % datasetid)
 
     if os.path.exists(filepath):
         # Replace local path with remote path before uploading

--- a/pyclowder/collections.py
+++ b/pyclowder/collections.py
@@ -96,7 +96,7 @@ def get_datasets(connector, host, key, collectionid):
     datasetid -- the collection to get datasets of
     """
 
-    url = posixpath.join(host, "api/collections/%s/datasets?key=%s" % (host, collectionid, key)
+    url = posixpath.join(host, "api/collections/%s/datasets?key=%s" % (collectionid, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)

--- a/pyclowder/collections.py
+++ b/pyclowder/collections.py
@@ -6,7 +6,7 @@ This module provides simple wrappers around the clowder Collections API
 import json
 import logging
 import requests
-
+import posixpath
 from pyclowder.client import ClowderClient
 
 
@@ -27,26 +27,26 @@ def create_empty(connector, host, key, collectionname, description, parentid=Non
 
     if parentid:
         if spaceid:
-            url = '%sapi/collections/newCollectionWithParent?key=%s' % (host, key)
+            url = posixpath.join(host, 'api/collections/newCollectionWithParent?key=%s' % key)
             result = requests.post(url, headers={"Content-Type": "application/json"},
                                    data=json.dumps({"name": collectionname, "description": description,
                                                     "parentId": [parentid], "space": spaceid}),
                                    verify=connector.ssl_verify if connector else True)
         else:
-            url = '%sapi/collections/newCollectionWithParent?key=%s' % (host, key)
+            url = posixpath.join(host, 'api/collections/newCollectionWithParent?key=%s' % key)
             result = requests.post(url, headers={"Content-Type": "application/json"},
                                    data=json.dumps({"name": collectionname, "description": description,
                                                     "parentId": [parentid]}),
                                    verify=connector.ssl_verify if connector else True)
     else:
         if spaceid:
-            url = '%sapi/collections?key=%s' % (host, key)
+            url = posixpath.join(host, 'api/collections?key=%s' % key)
             result = requests.post(url, headers={"Content-Type": "application/json"},
                                    data=json.dumps({"name": collectionname, "description": description,
                                                     "space": spaceid}),
                                    verify=connector.ssl_verify if connector else True)
         else:
-            url = '%sapi/collections?key=%s' % (host, key)
+            url = posixpath.join(host, 'api/collections?key=%s' % key)
             result = requests.post(url, headers={"Content-Type": "application/json"},
                                    data=json.dumps({"name": collectionname, "description": description}),
                                    verify=connector.ssl_verify if connector else True)
@@ -59,7 +59,7 @@ def create_empty(connector, host, key, collectionname, description, parentid=Non
 
 
 def delete(connector, host, key, collectionid):
-    url = "%sapi/collections/%s?key=%s" % (host, collectionid, key)
+    url = posixpath.join(host, "api/collections/%s?key=%s" % (collectionid, key))
 
     result = requests.delete(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -77,7 +77,7 @@ def get_child_collections(connector, host, key, collectionid):
     collectionid -- the collection to get children of
     """
 
-    url = "%sapi/collections/%s/getChildCollections?key=%s" % (host, collectionid, key)
+    url = posixpath.join(host, "api/collections/%s/getChildCollections?key=%s" % (collectionid, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -96,7 +96,7 @@ def get_datasets(connector, host, key, collectionid):
     datasetid -- the collection to get datasets of
     """
 
-    url = "%sapi/collections/%s/datasets?key=%s" % (host, collectionid, key)
+    url = posixpath.join(host, "api/collections/%s/datasets?key=%s" % (host, collectionid, key)
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -126,7 +126,7 @@ def upload_preview(connector, host, key, collectionid, previewfile, previewmetad
     headers = {'Content-Type': 'application/json'}
 
     # upload preview
-    url = '%sapi/previews?key=%s' % (host, key)
+    url = posixpath.join(host, 'api/previews?key=%s' % key)
     with open(previewfile, 'rb') as filebytes:
         result = requests.post(url, files={"File": filebytes},
                                verify=connector.ssl_verify if connector else True)
@@ -136,14 +136,14 @@ def upload_preview(connector, host, key, collectionid, previewfile, previewmetad
 
     # associate uploaded preview with original collection
     if collectionid and not (previewmetadata and 'section_id' in previewmetadata and previewmetadata['section_id']):
-        url = '%sapi/collections/%s/previews/%s?key=%s' % (host, collectionid, previewid, key)
+        url = posixpath.join(host, 'api/collections/%s/previews/%s?key=%s' % (collectionid, previewid, key))
         result = requests.post(url, headers=headers, data=json.dumps({}),
                                verify=connector.ssl_verify if connector else True)
         result.raise_for_status()
 
     # associate metadata with preview
     if previewmetadata is not None:
-        url = '%sapi/previews/%s/metadata?key=%s' % (host, previewid, key)
+        url = posixpath.join(host, 'api/previews/%s/metadata?key=%s' % (previewid, key))
         result = requests.post(url, headers=headers, data=json.dumps(previewmetadata),
                                verify=connector.ssl_verify if connector else True)
     result.raise_for_status()

--- a/pyclowder/datasets.py
+++ b/pyclowder/datasets.py
@@ -6,12 +6,8 @@ This module provides simple wrappers around the clowder Datasets API
 import json
 import logging
 import os
-import tempfile
-
-import requests
+import posixpath
 from pyclowder.client import ClowderClient
-import pyclowder.api.v2.datasets as v2datasets
-import pyclowder.api.v1.datasets as v1datasets
 from pyclowder.collections import get_datasets, get_child_collections, delete as delete_collection
 from pyclowder.utils import StatusMessage
 
@@ -207,7 +203,7 @@ def upload_tags(connector, host, key, datasetid, tags):
     connector.status_update(StatusMessage.processing, {"type": "dataset", "id": datasetid}, "Uploading dataset tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%sapi/datasets/%s/tags?key=%s' % (client.host, datasetid, client.key)
+    url = posixpath.join(client.host, 'api/datasets/%s/tags?key=%s' % (datasetid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 

--- a/pyclowder/datasets.py
+++ b/pyclowder/datasets.py
@@ -47,7 +47,6 @@ def delete(connector, host, key, datasetid):
     """
     client = ClowderClient(host=host, key=key)
     result = datasets.delete(connector, client, datasetid)
-    result.raise_for_status()
 
     return json.loads(result.text)
 

--- a/pyclowder/datasets.py
+++ b/pyclowder/datasets.py
@@ -47,8 +47,7 @@ def delete(connector, host, key, datasetid):
     """
     client = ClowderClient(host=host, key=key)
     result = datasets.delete(connector, client, datasetid)
-
-    return json.loads(result.text)
+    return result
 
 
 def delete_by_collection(connector, host, key, collectionid, recursive=True, delete_colls=False):

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -109,7 +109,6 @@ def delete(connector, host, key, fileid):
         """
     client = ClowderClient(host=host, key=key)
     result = files.delete(connector, client, fileid)
-    result.raise_for_status()
 
     return json.loads(result.text)
 

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -6,7 +6,7 @@ This module provides simple wrappers around the clowder Files API
 import json
 import logging
 import os
-
+import posixpath
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
@@ -235,7 +235,7 @@ def upload_tags(connector, host, key, fileid, tags):
     connector.message_process({"type": "file", "id": fileid}, "Uploading file tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%sapi/files/%s/tags?key=%s' % (client.host, fileid, client.key)
+    url = posixpath.join(client.host, 'api/files/%s/tags?key=%s' % (fileid, client.key))
     result = connector.post(url, headers=headers, data=json.dumps(tags),
                             verify=connector.ssl_verify if connector else True)
 
@@ -284,7 +284,7 @@ def upload_to_dataset(connector, host, key, datasetid, filepath, check_duplicate
             if filepath.startswith(connector.mounted_paths[source_path]):
                 return _upload_to_dataset_local(connector, client.host, client.key, datasetid, filepath)
 
-        url = '%sapi/uploadToDataset/%s?key=%s' % (client.host, datasetid, client.key)
+        url = posixpath.join(client.host, 'api/uploadToDataset/%s?key=%s' % (datasetid, client.key))
 
         if os.path.exists(filepath):
             filename = os.path.basename(filepath)

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -109,8 +109,7 @@ def delete(connector, host, key, fileid):
         """
     client = ClowderClient(host=host, key=key)
     result = files.delete(connector, client, fileid)
-
-    return json.loads(result.text)
+    return result
 
 def submit_extraction(connector, host, key, fileid, extractorname):
     """Submit file for extraction by given extractor.

--- a/pyclowder/geostreams.py
+++ b/pyclowder/geostreams.py
@@ -5,7 +5,7 @@ This module provides simple wrappers around the clowder Geostreams API
 
 import json
 import logging
-
+import posixpath
 import requests
 
 
@@ -36,7 +36,7 @@ def create_sensor(connector, host, key, sensorname, geom, type, region):
         }
     }
 
-    url = "%sapi/geostreams/sensors?key=%s" % (host, key)
+    url = posixpath.join(host, "api/geostreams/sensors?key=%s" % key)
 
     result = requests.post(url, headers={'Content-type': 'application/json'},
                            data=json.dumps(body),
@@ -75,7 +75,7 @@ def create_stream(connector, host, key, streamname, sensorid, geom, properties=N
         "sensor_id": str(sensorid)
     }
 
-    url = "%sapi/geostreams/streams?key=%s" % (host, key)
+    url = posixpath.join(host, "api/geostreams/streams?key=%s" % key)
 
     result = requests.post(url, headers={'Content-type': 'application/json'},
                            data=json.dumps(body),
@@ -116,7 +116,7 @@ def create_datapoint(connector, host, key, streamid, geom, starttime, endtime, p
         "stream_id": str(streamid)
     }
 
-    url = '%sapi/geostreams/datapoints?key=%s' % (host, key)
+    url = posixpath.join(host, 'api/geostreams/datapoints?key=%s' % key)
 
     result = requests.post(url, headers={'Content-type': 'application/json'},
                            data=json.dumps(body),
@@ -141,7 +141,7 @@ def get_sensor_by_name(connector, host, key, sensorname):
 
     logger = logging.getLogger(__name__)
 
-    url = "%sapi/geostreams/sensors?sensor_name=%s&key=%s" % (host, sensorname, key)
+    url = posixpath.join(host, "api/geostreams/sensors?sensor_name=%s&key=%s" % (sensorname, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -167,7 +167,7 @@ def get_sensors_by_circle(connector, host, key, lon, lat, radius=0):
     radius -- distance in meters around point to search
     """
 
-    url = "%sapi/geostreams/sensors?geocode=%s,%s,%s&key=%s" % (host, lat, lon, radius, key)
+    url = posixpath.join(host, "api/geostreams/sensors?geocode=%s,%s,%s&key=%s" % (lat, lon, radius, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -192,10 +192,9 @@ def get_sensors_by_polygon(connector, host, key, coord_list):
     """
 
     coord_strings = [str(i) for i in coord_list]
-    url = "%sapi/geostreams/sensors?geocode=%s&key=%s" % (host, ','.join(coord_strings), key)
+    url = posixpath.join(host, "api/geostreams/sensors?geocode=%s&key=%s" % (','.join(coord_strings), key))
 
-    result = requests.get(url,
-                          verify=connector.ssl_verify if connector else True)
+    result = requests.get(url, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
 
     # Return first sensor
@@ -218,7 +217,7 @@ def get_stream_by_name(connector, host, key, streamname):
 
     logger = logging.getLogger(__name__)
 
-    url = "%sapi/geostreams/streams?stream_name=%s&key=%s" % (host, streamname, key)
+    url = posixpath.join(host, "api/geostreams/streams?stream_name=%s&key=%s" % (streamname, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -244,7 +243,7 @@ def get_streams_by_circle(connector, host, key, lon, lat, radius=0):
     radius -- distance in meters around point to search
     """
 
-    url = "%sapi/geostreams/stream?geocode=%s,%s,%s&key=%s" % (host, lat, lon, radius, key)
+    url = posixpath.join(host, "api/geostreams/stream?geocode=%s,%s,%s&key=%s" % (lat, lon, radius, key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)
@@ -268,7 +267,7 @@ def get_streams_by_polygon(connector, host, key, coord_list):
     """
 
     coord_strings = [str(i) for i in coord_list]
-    url = "%sapi/geostreams/stream?geocode=%s&key=%s" % (host, ','.join(coord_strings), key)
+    url = posixpath.join(host, "api/geostreams/stream?geocode=%s&key=%s" % (','.join(coord_strings), key))
 
     result = requests.get(url,
                           verify=connector.ssl_verify if connector else True)

--- a/pyclowder/sections.py
+++ b/pyclowder/sections.py
@@ -5,7 +5,7 @@ This module provides simple wrappers around the clowder Datasets API
 
 import json
 import logging
-
+import posixpath
 import requests
 
 
@@ -23,7 +23,7 @@ def upload(connector, host, key, sectiondata):
     headers = {'Content-Type': 'application/json'}
 
     # upload section
-    url = '%sapi/sections?key=%s' % (host, key)
+    url = posixpath.join(host, 'api/sections?key=%s' % key)
     result = requests.post(url, headers=headers, data=json.dumps(sectiondata),
                            verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -48,7 +48,7 @@ def upload_tags(connector, host, key, sectionid, tags):
     connector.message_process({"type": "section", "id": sectionid}, "Uploading section tags.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%sapi/sections/%s/tags?key=%s' % (host, sectionid, key)
+    url = posixpath.join(host, 'api/sections/%s/tags?key=%s' % (sectionid, key))
     result = requests.post(url, headers=headers, data=json.dumps(tags),
                            verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
@@ -69,7 +69,7 @@ def upload_description(connector, host, key, sectionid, description):
                               "Uploading section description.")
 
     headers = {'Content-Type': 'application/json'}
-    url = '%sapi/sections/%s/description?key=%s' % (host, sectionid, key)
+    url = posixpath.join(host, 'api/sections/%s/description?key=%s' % (sectionid, key))
     result = requests.post(url, headers=headers, data=json.dumps(description),
                            verify=connector.ssl_verify if connector else True)
     result.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'description.rst').read_text(encoding='utf-8')
 
 setup(
     name='pyclowder',
-    version='3.0.5',
+    version='3.0.6',
     description='Python SDK for the Clowder Data Management System',
     long_description=long_description,
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / 'description.rst').read_text(encoding='utf-8')
 
 setup(
     name='pyclowder',
-    version='3.0.6',
+    version='3.0.7',
     description='Python SDK for the Clowder Data Management System',
     long_description=long_description,
 


### PR DESCRIPTION
Some new endpoints had `%s/api` and others had `%sapi` which caused issues for backwards compatibility. This replaces all calls in both versions with posixpath.join, which should return a valid URL whether the host has a trailing slash or not.