### PR TITLE
dataset get file list broken for v2, route changed on v2 backend

### DIFF
--- a/pyclowder/api/v2/datasets.py
+++ b/pyclowder/api/v2/datasets.py
@@ -166,7 +166,7 @@ def get_file_list(connector, client, datasetid):
     result = requests.get(url, headers=headers, verify=connector.ssl_verify if connector else True)
     result.raise_for_status()
 
-    return json.loads(result.text)
+    return json.loads(result.text)['data']
 
 
 def remove_metadata(connector, client, datasetid, extractor=None):

--- a/pyclowder/datasets.py
+++ b/pyclowder/datasets.py
@@ -128,7 +128,7 @@ def get_file_list(connector, host, key, datasetid):
     datasetid -- the dataset to get filelist of
     """
     client = ClowderClient(host=host, key=key)
-    file_list = datasets.get_file_list(connector, client, datasetid)['data']
+    file_list = datasets.get_file_list(connector, client, datasetid)
     return file_list
 
 

--- a/pyclowder/datasets.py
+++ b/pyclowder/datasets.py
@@ -128,7 +128,7 @@ def get_file_list(connector, host, key, datasetid):
     datasetid -- the dataset to get filelist of
     """
     client = ClowderClient(host=host, key=key)
-    file_list = datasets.get_file_list(connector, client, datasetid)
+    file_list = datasets.get_file_list(connector, client, datasetid)['data']
     return file_list
 
 


### PR DESCRIPTION
To replicate the bug:

Run a dataset extractor (I ran the huggingface ray extractor.)

In connectors._build_resource these lines cause an error:

```
 datasetinfo = pyclowder.datasets.get_info(self, host, secret_key, datasetid)
                filelist = pyclowder.datasets.get_file_list(self, host, secret_key, datasetid)
                triggering_file = None
                for f in filelist:
                    if f['id'] == fileid:
                        triggering_file = f['filename']
                        break
```
This is because what is returned by the /files endpoint in the dataset router has changed. Before it was just a list of files, and now the response is the Paged response, which contains a "metadata" and "data." When it tries to find the f["id"] in those objects, it is not there so it throws an error.

My fix will be to have datasets.get_file_list to return the files, which is the "data" field coming from the backend route.
