### PR TITLE
Modify download apis for minio mounted fs

### DIFF
--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -309,6 +309,8 @@ class Connector(object):
         (fd, md_file) = tempfile.mkstemp(suffix=md_name, dir=md_dir)
 
         with os.fdopen(fd, "wb") as tmp_file:
+            print("Writing metadata to %s" % md_file)
+            print(file_md)
             tmp_file.write(json.dumps(file_md))
 
         return (md_dir, md_file)
@@ -327,12 +329,21 @@ class Connector(object):
         tmp_dirs_created.append(temp_link_dir)
 
         # Check if miniomounted path is set and if the file is in the minio mounted path
-        if self.minio_mounted_path:
-            for file in resource['files']:
-                file_path = self._check_for_local_file(file, file['id'])
-                if file_path:
-                    # print("Found file locally: %s" % file_path)
-                    located_files.append(file_path)
+        # if self.minio_mounted_path:
+        #     for file in resource['files']:
+        #         file_path = self._check_for_local_file(file, file['id'])
+        #         if not file_path:
+        #             missing_files.append(file)
+        #         else:
+        #             md_file_path = file['name'].split('.')[0] + "_metadata.json"
+        #             (file_md_dir, file_md_tmp) = self._download_file_metadata(host, secret_key, file['id'], md_file_path)
+        #             located_files.append(file_path)
+        #             located_files.append(file_md_tmp)
+        #             tmp_files_created.append(file_md_tmp)
+        #             tmp_dirs_created.append(file_md_dir)
+                
+        # else:
+        
         #check if any files in dataset accessible locally
         ds_file_list = pyclowder.datasets.get_file_list(self, host, secret_key, resource["id"])
         for ds_file in ds_file_list:
@@ -349,7 +360,7 @@ class Connector(object):
 
                 # Also get file metadata in format expected by extrator
                 (file_md_dir, file_md_tmp) = self._download_file_metadata(host, secret_key, ds_file['id'],
-                                                                          ds_file['filepath'])
+                                                                        ds_file['filepath'])
                 located_files.append(file_path)
                 located_files.append(file_md_tmp)
                 tmp_files_created.append(file_md_tmp)
@@ -393,6 +404,7 @@ class Connector(object):
             except Exception as e:
                 logger.exception("No files found and download failed")
 
+        print("File paths: %s" % file_paths)
         return (file_paths, tmp_files_created, tmp_dirs_created)
 
     # pylint: disable=too-many-branches,too-many-statements

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -277,7 +277,6 @@ class Connector(object):
         # Check if file is present in a minio mount (only valid for Clowder v2)
         if self.minio_mounted_path and file_id:
             minio_file_path = self.minio_mounted_path + "/" + file_id
-            print("Checking for minio local file: %s" % minio_file_path)
             if os.path.isfile(minio_file_path):
                 return minio_file_path
 
@@ -327,7 +326,14 @@ class Connector(object):
         temp_link_dir = tempfile.mkdtemp()
         tmp_dirs_created.append(temp_link_dir)
 
-        # first check if any files in dataset accessible locally
+        # Check if miniomounted path is set and if the file is in the minio mounted path
+        if self.minio_mounted_path:
+            for file in resource['files']:
+                file_path = self._check_for_local_file(file, file['id'])
+                if file_path:
+                    # print("Found file locally: %s" % file_path)
+                    located_files.append(file_path)
+        #check if any files in dataset accessible locally
         ds_file_list = pyclowder.datasets.get_file_list(self, host, secret_key, resource["id"])
         for ds_file in ds_file_list:
             file_path = self._check_for_local_file(ds_file)

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -287,7 +287,6 @@ class Connector(object):
             # first simply check if file is present locally
             if os.path.isfile(file_path):
                 return file_path
-            
             # otherwise check any mounted paths...
             if len(self.mounted_paths) > 0:
                 for source_path in self.mounted_paths:

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -63,7 +63,7 @@ class Connector(object):
     """
 
     def __init__(self, extractor_name, extractor_info, check_message=None, process_message=None, ssl_verify=True,
-                 mounted_paths=None, clowder_url=None, max_retry=10, extractor_key=None, clowder_email=None):
+                 mounted_paths=None, minio_mounted_path=None, clowder_url=None, max_retry=10, extractor_key=None, clowder_email=None):
         self.extractor_name = extractor_name
         self.extractor_info = extractor_info
         self.check_message = check_message
@@ -73,6 +73,10 @@ class Connector(object):
             self.mounted_paths = {}
         else:
             self.mounted_paths = mounted_paths
+        if minio_mounted_path is None:
+            self.minio_mounted_path = ''
+        else:
+            self.minio_mounted_path = minio_mounted_path
         self.clowder_url = clowder_url
         self.clowder_email = clowder_email
         self.extractor_key = extractor_key
@@ -268,8 +272,14 @@ class Connector(object):
                 "metadata": body['metadata']
             }
 
-    def _check_for_local_file(self, file_metadata):
+    def _check_for_local_file(self, file_metadata, file_id=None):
         """ Try to get pointer to locally accessible copy of file for extractor."""
+        # Check if file is present in a minio mount (only valid for Clowder v2)
+        if self.minio_mounted_path and file_id:
+            minio_file_path = self.minio_mounted_path + "/" + file_id
+            print("Checking for minio local file: %s" % minio_file_path)
+            if os.path.isfile(minio_file_path):
+                return minio_file_path
 
         # first check if file is accessible locally
         if 'filepath' in file_metadata:
@@ -278,7 +288,7 @@ class Connector(object):
             # first simply check if file is present locally
             if os.path.isfile(file_path):
                 return file_path
-
+            
             # otherwise check any mounted paths...
             if len(self.mounted_paths) > 0:
                 for source_path in self.mounted_paths:
@@ -427,7 +437,7 @@ class Connector(object):
                         try:
                             if check_result != pyclowder.utils.CheckMessage.bypass:
                                 file_metadata = pyclowder.files.download_info(self, host, secret_key, resource["id"])
-                                file_path = self._check_for_local_file(file_metadata)
+                                file_path = self._check_for_local_file(file_metadata, resource["id"])
                                 if not file_path:
                                     file_path = pyclowder.files.download(self, host, secret_key, resource["id"],
                                                                          resource["intermediate_id"],
@@ -628,10 +638,10 @@ class RabbitMQConnector(Connector):
     # pylint: disable=too-many-arguments
     def __init__(self, extractor_name, extractor_info,
                  rabbitmq_uri, rabbitmq_key=None, rabbitmq_queue=None,
-                 check_message=None, process_message=None, ssl_verify=True, mounted_paths=None,
+                 check_message=None, process_message=None, ssl_verify=True, mounted_paths=None, minio_mounted_path=None,
                  heartbeat=10, clowder_url=None, max_retry=10, extractor_key=None, clowder_email=None):
         super(RabbitMQConnector, self).__init__(extractor_name, extractor_info, check_message, process_message,
-                                                ssl_verify, mounted_paths, clowder_url, max_retry, extractor_key, clowder_email)
+                                                ssl_verify, mounted_paths, minio_mounted_path, clowder_url, max_retry, extractor_key, clowder_email)
         self.rabbitmq_uri = rabbitmq_uri
         self.rabbitmq_key = rabbitmq_key
         if rabbitmq_queue is None:
@@ -756,7 +766,7 @@ class RabbitMQConnector(Connector):
                 job_id = None
 
             self.worker = RabbitMQHandler(self.extractor_name, self.extractor_info, job_id, self.check_message,
-                                          self.process_message, self.ssl_verify, self.mounted_paths, self.clowder_url,
+                                          self.process_message, self.ssl_verify, self.mounted_paths, self.minio_mounted_path, self.clowder_url,
                                           method, header, body)
             self.worker.start_thread(json_body)
 
@@ -836,10 +846,10 @@ class RabbitMQHandler(Connector):
     """
 
     def __init__(self, extractor_name, extractor_info, job_id, check_message=None, process_message=None, ssl_verify=True,
-                 mounted_paths=None, clowder_url=None, method=None, header=None, body=None, max_retry=10):
+                 mounted_paths=None, minio_mounted_path=None, clowder_url=None, method=None, header=None, body=None, max_retry=10):
 
         super(RabbitMQHandler, self).__init__(extractor_name, extractor_info, check_message, process_message,
-                                              ssl_verify, mounted_paths, clowder_url, max_retry)
+                                              ssl_verify, mounted_paths, minio_mounted_path,clowder_url, max_retry)
         self.method = method
         self.header = header
         self.body = body

--- a/pyclowder/connectors.py
+++ b/pyclowder/connectors.py
@@ -309,8 +309,6 @@ class Connector(object):
         (fd, md_file) = tempfile.mkstemp(suffix=md_name, dir=md_dir)
 
         with os.fdopen(fd, "wb") as tmp_file:
-            print("Writing metadata to %s" % md_file)
-            print(file_md)
             tmp_file.write(json.dumps(file_md))
 
         return (md_dir, md_file)
@@ -328,23 +326,6 @@ class Connector(object):
         temp_link_dir = tempfile.mkdtemp()
         tmp_dirs_created.append(temp_link_dir)
 
-        # Check if miniomounted path is set and if the file is in the minio mounted path
-        # if self.minio_mounted_path:
-        #     for file in resource['files']:
-        #         file_path = self._check_for_local_file(file, file['id'])
-        #         if not file_path:
-        #             missing_files.append(file)
-        #         else:
-        #             md_file_path = file['name'].split('.')[0] + "_metadata.json"
-        #             (file_md_dir, file_md_tmp) = self._download_file_metadata(host, secret_key, file['id'], md_file_path)
-        #             located_files.append(file_path)
-        #             located_files.append(file_md_tmp)
-        #             tmp_files_created.append(file_md_tmp)
-        #             tmp_dirs_created.append(file_md_dir)
-                
-        # else:
-        
-        #check if any files in dataset accessible locally
         ds_file_list = pyclowder.datasets.get_file_list(self, host, secret_key, resource["id"])
         for ds_file in ds_file_list:
             file_path = self._check_for_local_file(ds_file)
@@ -404,7 +385,6 @@ class Connector(object):
             except Exception as e:
                 logger.exception("No files found and download failed")
 
-        print("File paths: %s" % file_paths)
         return (file_paths, tmp_files_created, tmp_dirs_created)
 
     # pylint: disable=too-many-branches,too-many-statements

--- a/pyclowder/extractors.py
+++ b/pyclowder/extractors.py
@@ -72,6 +72,7 @@ class Extractor(object):
         clowder_email = os.getenv("CLOWDER_EMAIL", "")
         logging_config = os.getenv("LOGGING")
         mounted_paths = os.getenv("MOUNTED_PATHS", "{}")
+        minio_mounted_path = os.getenv("MINIO_MOUNTED_PATH", "")
         input_file_path = os.getenv("INPUT_FILE_PATH")
         output_file_path = os.getenv("OUTPUT_FILE_PATH")
         connector_default = "RabbitMQ"
@@ -105,6 +106,8 @@ class Extractor(object):
                                  help='rabbitMQ queue name (default=%s)' % rabbitmq_queuename)
         self.parser.add_argument('--mounts', '-m', dest="mounted_paths", default=mounted_paths,
                                  help="dictionary of {'remote path':'local path'} mount mappings")
+        self.parser.add_argument('--minio-mount', dest="minio_mounted_path", default=minio_mounted_path,
+                                    help="path to mount Minio storage")
         self.parser.add_argument('--input-file-path', '-ifp', dest="input_file_path", default=input_file_path,
                                  help="Full path to local input file to be processed (used by Big Data feature)")
         self.parser.add_argument('--output-file-path', '-ofp', dest="output_file_path", default=output_file_path,
@@ -175,6 +178,7 @@ class Extractor(object):
                                               rabbitmq_key=rabbitmq_key,
                                               rabbitmq_queue=self.args.rabbitmq_queuename,
                                               mounted_paths=json.loads(self.args.mounted_paths),
+                                              minio_mounted_path=self.args.minio_mounted_path,
                                               clowder_url=self.args.clowder_url,
                                               max_retry=self.args.max_retry,
                                               heartbeat=self.args.heartbeat,
@@ -193,6 +197,7 @@ class Extractor(object):
                                          process_message=self.process_message,
                                          picklefile=self.args.hpc_picklefile,
                                          mounted_paths=json.loads(self.args.mounted_paths),
+                                         minio_mounted_path=self.args.minio_mounted_path,
                                          max_retry=self.args.max_retry)
                 threading.Thread(target=connector.listen, name="HPCConnector").start()
 

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -38,7 +38,7 @@ def get_download_url(connector, host, key, fileid, intermediatefileid=None, ext=
 
 
 # pylint: disable=too-many-arguments
-def download(connector, host, key, fileid, intermediatefileid=None, ext="", tracking=True):
+def download(connector, host, key, fileid, intermediatefileid=None, ext="", tracking=True, mounted_filesystem = False, mounted_dir = "None"):
     """Download file to be processed from Clowder.
 
     Keyword arguments:
@@ -49,7 +49,14 @@ def download(connector, host, key, fileid, intermediatefileid=None, ext="", trac
     intermediatefileid -- either same as fileid, or the intermediate file to be used
     ext -- the file extension, the downloaded file will end with this extension
     tracking -- should the download action be tracked
+    mounted_filesystem -- if the minio storage is mounted to the local filesystem
     """
+
+    if mounted_filesystem:
+        if mounted_dir == "None":
+            mounted_dir = "/clowderfs"
+        inputfilename = "/clowderfs/" + fileid
+        return inputfilename
     client = ClowderClient(host=host, key=key)
     inputfilename = files.download(connector, client, fileid, intermediatefileid, ext)
     return inputfilename

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -51,6 +51,14 @@ def download(connector, host, key, fileid, intermediatefileid=None, ext="", trac
     tracking -- should the download action be tracked
     """
     client = ClowderClient(host=host, key=key)
+    # Check if minio mounted path is set
+    minio_mounted_path = os.getenv("MINIO_MOUNTED_PATH", "")
+    if minio_mounted_path:
+        # Check if the file is stored in Minio mount path
+        minio_file_path = minio_mounted_path + "/" + fileid
+        if os.path.isfile(minio_file_path):
+            return minio_file_path
+    # Else download the file from Clowder
     inputfilename = files.download(connector, client, fileid, intermediatefileid, ext)
     return inputfilename
 

--- a/pyclowder/files.py
+++ b/pyclowder/files.py
@@ -38,7 +38,7 @@ def get_download_url(connector, host, key, fileid, intermediatefileid=None, ext=
 
 
 # pylint: disable=too-many-arguments
-def download(connector, host, key, fileid, intermediatefileid=None, ext="", tracking=True, mounted_filesystem = False, mounted_dir = "None"):
+def download(connector, host, key, fileid, intermediatefileid=None, ext="", tracking=True):
     """Download file to be processed from Clowder.
 
     Keyword arguments:
@@ -49,14 +49,7 @@ def download(connector, host, key, fileid, intermediatefileid=None, ext="", trac
     intermediatefileid -- either same as fileid, or the intermediate file to be used
     ext -- the file extension, the downloaded file will end with this extension
     tracking -- should the download action be tracked
-    mounted_filesystem -- if the minio storage is mounted to the local filesystem
     """
-
-    if mounted_filesystem:
-        if mounted_dir == "None":
-            mounted_dir = "/clowderfs"
-        inputfilename = "/clowderfs/" + fileid
-        return inputfilename
     client = ClowderClient(host=host, key=key)
     inputfilename = files.download(connector, client, fileid, intermediatefileid, ext)
     return inputfilename


### PR DESCRIPTION
## APIs for File Downloads with MinIO Mounted Directory

This update modifies how files are downloaded in an extractor when the environment variable MINIO_MOUNTED_PATH is set. Instead of downloading files to the /tmp folder, the API uses the S3fs-mounted directory to load files directly. This improves performance by eliminating redundant downloads and enabling direct access to files stored in MinIO.

---

### **Testing Steps**

To test this functionality, we need to set up an S3fs mount and configure the environment appropriately.

---

#### **1. Prerequisites**
Ensure the following are in place before testing:
- MinIO is set up and running.
- s3fs is installed on your system. Follow the installation instructions at [s3fs GitHub](https://github.com/s3fs-fuse/s3fs-fuse).

---

#### **2. Expose the minio-nginx Container**
To expose MinIO at port 9000, add the following configuration to your docker-compose.yml file:

```yaml
minio-nginx:
  image: nginx:1.19.2-alpine
  restart: unless-stopped
  hostname: nginx
  ports:
    - "9000:9000"
  networks:
    - clowder2
  volumes:
    - ./deployments/docker/minio-nginx.conf:/etc/nginx/nginx.conf:ro
  depends_on:
    - minio1
    - minio2
    - minio3
    - minio4
```

#### **3. Set the MINIO_ENDPOINT Environment Variable**
Set the MINIO_ENDPOINT environment variable to the URL of the exposed MinIO service. For local development, the value should be:

```bash
MINIO_ENDPOINT="http://localhost:9000"
```


---

#### **4. Create a .miniocred File**
In your home directory (or another preferred location), create a file named .miniocred. Populate it with your MinIO credentials in the format:

`ACCESS_KEY_ID:SECRET_ACCESS_KEY`


For default Docker values, use:

`minioadmin:minioadmin`


Ensure the file has secure permissions:

```bash
chmod 600 ~/.miniocred
```

---

#### **5. Mount the MinIO Filesystem**
1. Create a directory to mount the MinIO filesystem. For example:
   
```bash
   mkdir ~/clowderfs
```

2. Run the following command to mount the MinIO bucket to this directory:
   
```bash
   s3fs clowder ~/clowderfs \
     -o passwd_file=~/.miniocred \
     -o use_path_request_style \
     -o url=$MINIO_ENDPOINT \
     -o allow_other
```
3. Verify the mount by listing files in the directory:
   
```bash
   ls ~/clowderfs
```
You should see the clowder files in the MinIO bucket listed by fileids

---

#### **6. Set the MINIO_MOUNTED_PATH Environment Variable**
Set the MINIO_MOUNTED_PATH environment variable to the mounted directory:

```bash
MINIO_MOUNTED_PATH=~/clowderfs
```

---

#### **Test the Download File API in PyClowder**
Use the PyClowder API to test file downloads:
1. Run the download_file API and specify the file path.
2. The API should return a file path that points to the mounted directory (e.g., ~/clowderfs), confirming that files are being accessed directly from the mounted filesystem.

OR 

#### **Test with the Image-Classification-Dataset Extractor**
1. Clone the [image-classification-dataset extractor repository](https://github.com/clowder-framework/extractors-huggingface/tree/minio-mounted-extractors/pipeline-image-classification-file).
2. Switch to the minio-mounted-extractor branch:
   
```bash
   git checkout minio-mounted-extractor
```
3. Run the extractor locally.
4. Observe the logs during execution. The listed filenames should reference the MinIO mounted directory (e.g., ~/clowderfs), indicating that files are being accessed correctly.

---